### PR TITLE
fix(package): update warp-contracts

### DIFF
--- a/inference/package.json
+++ b/inference/package.json
@@ -29,9 +29,9 @@
     "arweave": "1.12.4",
     "json-schema-to-typescript": "^11.0.1",
     "typescript": "^4.6.2",
-    "warp-contracts": "1.3.4-beta.0",
+    "warp-contracts": "^1.4.14",
     "warp-contracts-lmdb": "^1.1.9",
-    "warp-contracts-plugin-deploy": "^1.0.1",
+    "warp-contracts-plugin-deploy": "^1.0.9",
     "warp-contracts-plugin-fetch": "0.1.5",
     "warp-contracts-redis": "^0.1.2"
   },


### PR DESCRIPTION
`yarn build` fails with the current versions of warp-contracts and its dependency warp-contracts-plugin-deploy.

```
TypeError: this.warp.gwUrl is not a function
    at CreateContractImpl.postContract (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/node_modules/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts:178:48)
    at CreateContractImpl.deployContractBundlr (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/node_modules/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts:275:16)
    at async CreateContractImpl.deployFromSourceTx (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/node_modules/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts:115:35)
    at async CreateContractImpl.deploy (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/node_modules/warp-contracts-plugin-deploy/src/deploy/impl/CreateContractImpl.ts:57:12)
    at async deploy (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/src/deploy/deploy.ts:15:28)
    at async main (/private/var/folders/zv/ljvzwc350pncxrz14tfsnh5c0000gn/T/tmp.ivuX4dQA0w/danny/inference/examples/deploy/deploy-testnet.ts:13:24)
```

 Updating to latest fixes the issue.